### PR TITLE
Add family symbol activation

### DIFF
--- a/nodes/Family Instance By Point in Transaction.dyf
+++ b/nodes/Family Instance By Point in Transaction.dyf
@@ -37,6 +37,10 @@ elementlist = list()
 ST = StructuralType.NonStructural
 
 TransactionManager.Instance.EnsureInTransaction(doc)
+# Make sure the familysymbol is active
+if famtype.IsActive == False:
+	famtype.Activate()
+	doc.Regenerate()
 for point in points:
 	newobj = doc.Create.NewFamilyInstance(point.ToXyz(),famtype,ST)
 	elementlist.append(newobj)


### PR DESCRIPTION
If you load a new family to the project and run the script, Revit will refuse to place this family instance. 
You will firstly need to activate the family symbol before executing 'doc.Create.NewFamilyInstance'.